### PR TITLE
fix trailing slash problem

### DIFF
--- a/code/termlist-header.md
+++ b/code/termlist-header.md
@@ -10,7 +10,7 @@ permalink: /termlist
 
 **Date created:** 2013-10-23
 
-**Part of TDWG Standard:** http://www.tdwg.org/standards/638/
+**Part of TDWG Standard:** http://www.tdwg.org/standards/638
 
 **This version:** http://rs.tdwg.org/ac/doc/termlist/2013-10-23
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -10,7 +10,7 @@ permalink: /guide/
 
 **Date created:** 2013-10-15
 
-**Part of TDWG Standard:** http://www.tdwg.org/standards/638/
+**Part of TDWG Standard:** http://www.tdwg.org/standards/638
 
 **This version:** http://rs.tdwg.org/ac/doc/guide/2013-10-15
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ permalink: /introduction/
 
 **Date created:** 2013-10-23
 
-**Part of TDWG Standard:** http://www.tdwg.org/standards/638/
+**Part of TDWG Standard:** http://www.tdwg.org/standards/638
 
 **This version:** http://rs.tdwg.org/ac/doc/introduction/2013-10-23
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -10,7 +10,7 @@ permalink: /structure/
 
 **Date created:** 2013-10-23
 
-**Part of TDWG Standard:** http://www.tdwg.org/standards/638/
+**Part of TDWG Standard:** http://www.tdwg.org/standards/638
 
 **This version:** http://rs.tdwg.org/ac/doc/structure/2013-10-23
 

--- a/docs/termlist.md
+++ b/docs/termlist.md
@@ -10,7 +10,7 @@ permalink: /termlist/
 
 **Date created:** 2013-10-23
 
-**Part of TDWG Standard:** http://www.tdwg.org/standards/638/
+**Part of TDWG Standard:** http://www.tdwg.org/standards/638
 
 **This version:** http://rs.tdwg.org/ac/doc/termlist/2013-10-23
 


### PR DESCRIPTION
This is to fix issue #128 .  I think the only relevant places are in the four documents and the header template used to generate the term list document.  

@nielsklazenga, if you can give this a look, merge it if it looks OK.